### PR TITLE
Add ability to break by Word Count instead of target page count

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Automatically Paginate Posts ===
-Contributors: ethitter, thinkoomph
+Contributors: ethitter, thinkoomph, bendoh
 Donate link:
 Tags: paginate, nextpage, Quicktag
 Requires at least: 3.4
@@ -16,7 +16,7 @@ Automatically paginate WordPress content by inserting the &lt;!--nextpage--&gt; 
 
 Option is provided to control what post types are automatically paginated (default is just `post`). Supports `post`, `page`, and any public custom post types.
 
-Option is also provided to specify how many pages content should be broken out over.
+Option is also provided to specify how many pages content should be broken out over, or how many words should be included per page.
 
 == Installation ==
 
@@ -48,7 +48,13 @@ You can also use the filter `autopaging_post_types` to add support by appending 
 = 0.1 =
 * Initial release.
 
+= 0.2 =
+* Allow for number of words to be specified instead of number of pages.
+
 == Upgrade Notice ==
 
 = 0.1 =
 Initial release
+
+= 0.2 =
+* Allow for number of words to be specified instead of number of pages.


### PR DESCRIPTION
As per a comment left on the plugin page http://www.oomphinc.com/plugins-modules/automatically-paginate-posts/, I've gone ahead and added the ability to specify a word count to break a page at rather than a total number of pages. This has no effect on existing setups, but a user can choose to break by word count instead.

Hope things are going well Erick!
