### PR TITLE
Render shortcodes before paginating content

### DIFF
--- a/automatically-paginate-posts.php
+++ b/automatically-paginate-posts.php
@@ -369,7 +369,7 @@ class Automatically_Paginate_Posts {
 						continue;
 
 					//Start with post content, but alias to protect the raw content.
-					$content = $the_post->post_content;
+					$content = apply_filters('the_content', $the_post->post_content);
 
 					//Normalize post content to simplify paragraph counting and automatic paging. Accounts for content that hasn't been cleaned up by TinyMCE.
 					$content = preg_replace( '#<p>(.+?)</p>#i', "$1\r\n\r\n", $content );


### PR DESCRIPTION
the issue occurs when a shortcode crosses the line between two pages, and becomes more likely when longer shortcodes are used (aka shortcodes with a lot in their content area, or between the two tags).

For example a shortcode like this:

``` html
[show-to-logged-in-users]
<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent dapibus, neque id cursus faucibus, tortor neque egestas augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi, tincidunt quis, accumsan porttitor, facilisis luctus, metus</p>
[/show-to-logged-in-users]
```

The above will be split between two pages (assuming the contents inside the shortcode are long enough), and that breaks the shortcode, because on the first page there is only the opening tag, and on the second their is only the closing tag.

The solution I've found is to first render the shortcodes, then paginate their output.  This has the added benefit of being accurate (non logged in users will have no content, so there should only be one page, whereas logged in users should see two or more pages).
