### PR TITLE
Add wpautop to $the_post->post_content

### DIFF
--- a/automatically-paginate-posts.php
+++ b/automatically-paginate-posts.php
@@ -367,9 +367,10 @@ class Automatically_Paginate_Posts {
 						continue;
 
 					//Start with post content, but alias to protect the raw content.
-					$content = $the_post->post_content;
+					$content = wpautop( $the_post->post_content );
 
 					//Normalize post content to simplify paragraph counting and automatic paging. Accounts for content that hasn't been cleaned up by TinyMCE.
+					$content = preg_replace( ‘/(?=<p )(.*?)(>)/i’, ‘<p>’, $content );
 					$content = preg_replace( '#<p>(.+?)</p>#i', "$1\r\n\r\n", $content );
 					$content = preg_replace( '#<br(\s*/)?>#i', "\r\n", $content );
 


### PR DESCRIPTION
WordPress must have changed the output of post_content at some point, and now post_content return only text, without html paragraph notation, using wpautop can be a solution.
Also can be better to eventually stripe any inline-style of paragraph