### PR TITLE
Make Settings Section Name to be translable

### DIFF
--- a/automatically-paginate-posts.php
+++ b/automatically-paginate-posts.php
@@ -323,7 +323,7 @@ class Automatically_Paginate_Posts {
 		register_setting( 'reading', $this->option_name_num_pages, array( $this, 'sanitize_num_pages' ) );
 		register_setting( 'reading', $this->option_name_num_words, array( $this, 'sanitize_num_words' ) );
 
-		add_settings_section( 'autopaging', __( 'Automatically Paginate Posts', 'automatically-paginate-posts' ), '__return_false', 'reading' );
+		add_settings_section( 'autopaging', _x( 'Automatically Paginate Posts', 'Settings Section', 'automatically-paginate-posts' ), '__return_false', 'reading' );
 		add_settings_field( 'autopaging-post-types', __( 'Supported post types:', 'automatically-paginate-posts' ), array( $this, 'settings_field_post_types' ), 'reading', 'autopaging' );
 		add_settings_field( 'autopaging-paging-type', __( 'Split post by:', 'automatically-paginate-posts' ), array( $this, 'settings_field_paging_type' ), 'reading', 'autopaging' );
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -9,7 +9,7 @@ Requires PHP: 5.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-Automatically paginate posts by inserting the `<!--nextpage-->` Quicktag.
+Automatically paginate posts by inserting the &lt;!--nextpage--&gt; Quicktag.
 
 == Description ==
 


### PR DESCRIPTION
The current settings section name is the same as the plugin's name. We don't translate the plugin's name but we can translate the settings section name with meaning.